### PR TITLE
Add directline-postman

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ The following tools are available to globally install via NPM.
 | Name | Description | NPM |
 | ---- | ----------- |-----|
 | [chatdown-glob](packages/chatdown-glob/README.md) | Process multiple chatdown files in one command | ![NPM Version](https://img.shields.io/badge/npm-0.1.4-red.svg) |
+| [directline-postman](directline-postman/README.md) | Postman tools for debugging bots through the Direct Line | - |

--- a/directline-postman/Direct Line 3.0.postman_collection.json
+++ b/directline-postman/Direct Line 3.0.postman_collection.json
@@ -1,0 +1,176 @@
+{
+	"info": {
+		"_postman_id": "dd987fa5-5a5d-4b4a-92a8-8a9534b3e0e5",
+		"name": "Direct Line 3.0",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Start conversation",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "b9fac75e-3211-44d3-9115-7b2d128def15",
+						"exec": [
+							"pm.test(\"Save conversation ID\", () => {",
+							"    var jsonData = pm.response.json();",
+							"    pm.environment.set(\"conversationId\", jsonData.conversationId);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "https://directline.botframework.com/v3/directline/conversations",
+					"protocol": "https",
+					"host": [
+						"directline",
+						"botframework",
+						"com"
+					],
+					"path": [
+						"v3",
+						"directline",
+						"conversations"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Send event",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"type\": \"event\",\r\n    \"from\": {\r\n        \"id\": \"user1\"\r\n    },\r\n    \"name\": \"MyCustomEvent\",\r\n\t\"value\": {\r\n  \t\t\"myCustomProperty\": \"myCustomValue\"\r\n\t}\r\n}"
+				},
+				"url": {
+					"raw": "https://directline.botframework.com/v3/directline/conversations/{{conversationId}}/activities",
+					"protocol": "https",
+					"host": [
+						"directline",
+						"botframework",
+						"com"
+					],
+					"path": [
+						"v3",
+						"directline",
+						"conversations",
+						"{{conversationId}}",
+						"activities"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Send message",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n\t\"type\": \"message\",\r\n    \"from\": {\r\n        \"id\": \"user1\"\r\n    },\r\n    \"text\": \"hello\"\r\n}"
+				},
+				"url": {
+					"raw": "https://directline.botframework.com/v3/directline/conversations/{{conversationId}}/activities",
+					"protocol": "https",
+					"host": [
+						"directline",
+						"botframework",
+						"com"
+					],
+					"path": [
+						"v3",
+						"directline",
+						"conversations",
+						"{{conversationId}}",
+						"activities"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Receive activities",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "https://directline.botframework.com/v3/directline/conversations/{{conversationId}}/activities",
+					"protocol": "https",
+					"host": [
+						"directline",
+						"botframework",
+						"com"
+					],
+					"path": [
+						"v3",
+						"directline",
+						"conversations",
+						"{{conversationId}}",
+						"activities"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{directLineSecret}}",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "406e1bc2-29b0-40ae-a2aa-469537eb945c",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "2fc55f41-a1a7-4a9c-92f5-98fa10b06e4f",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}

--- a/directline-postman/Direct Line 3.0.postman_environment.json
+++ b/directline-postman/Direct Line 3.0.postman_environment.json
@@ -1,0 +1,23 @@
+{
+	"id": "1690aaef-b643-4f04-a2ad-ba734b1c7055",
+	"name": "Direct Line 3.0",
+	"values": [
+		{
+			"key": "directLineSecret",
+			"value": "",
+			"description": {
+				"content": "",
+				"type": "text/plain"
+			},
+			"enabled": true
+		},
+		{
+			"key": "conversationId",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2018-11-02T07:07:35.857Z",
+	"_postman_exported_using": "Postman/6.4.4"
+}

--- a/directline-postman/README.md
+++ b/directline-postman/README.md
@@ -1,0 +1,3 @@
+A Postman collection and a Postman enviroment for debugging chatbots through the Direct Line API 3.0.
+
+For details and usage please refer to the following blog post: https://peterbozso.github.io/2018/11/02/direct-line-postman.html

--- a/directline-postman/README.md
+++ b/directline-postman/README.md
@@ -1,3 +1,34 @@
-A Postman collection and a Postman enviroment for debugging chatbots through the Direct Line API 3.0.
+# Direct Line Postman Package
 
-For details and usage please refer to the following blog post: https://peterbozso.github.io/2018/11/02/direct-line-postman.html
+This package contains a Postman collection and a [Postman](https://www.getpostman.com/) environment for debugging Microsoft Bot Framework chatbots through the [Direct Line API 3.0.]((https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-direct-line-3-0-concepts?view=azure-bot-service-4.0))
+
+## Installation
+
+After downloading this folder, you can [import the whole package in one step](https://www.getpostman.com/docs/v6/postman/collections/data_formats) into Postman by using it's *Import Folder* functionality.
+
+## Setup
+
+To make the authentication against the Direct Line work, you need to [get your Direct Line secret](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-channel-connect-directline?view=azure-bot-service-4.0#manage-secret-keys) and set it as the value of the **directLineSecret** variable in the freshly imported **Direct Line 3.0** environment in Postman.
+
+## Usage
+
+The collection contains four requests that you can use for testing your chatbots through the Direct Line:
+
+* Start conversation
+* Send event
+* Send message
+* Receive activities
+
+The names of the requests are pretty self-explanatory if you are familiar with the Direct Line API 3.0.
+
+Using those four request types, the default testing workflow looks like this:
+
+1. Create a new conversation by issuing a **Start conversation** request.
+2. Using **Send event** and **Send message** to trigger the bot logic being tested.
+3. Check the conversation history with **Receive activities** to see if everything is okay.
+
+In the above list, sending an event and sending a message are pretty similar, since they are POST-ing the very same endpoint, but with a different body. Based on these and the [schema's documentation](https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#activity-object), you can easily send your own Activity object.
+
+## Notes
+
+For implementation details please refer to [this blog post.](https://peterbozso.github.io/2018/11/02/direct-line-postman.html)


### PR DESCRIPTION
Hi!

First of all, thanks for all the effort you guys put into these community repos, cool stuff, highly appreciated! :)

Regarding the actual pull request, I'd like to propose this small package of mine which contains a Postman collection and a Postman environment which you can use to conveniently end-to-end test and debug a chatbot through the Direct Line channel using Postman.
I usually develop multiple bots in parallel and almost all of them has some kind of integration through the Direct Line, usually using a couple of custom event type Activities.
You can read more about the details and the usage of this package here: https://peterbozso.github.io/2018/11/02/direct-line-postman.html

I hope you will find it as useful as I do and you'll deem it worthy to be merged into this repo! (No hard feelings if you won't, of course. ;))

Thanks,
Péter